### PR TITLE
Remove quality check from lovan annotation

### DIFF
--- a/workflows/viral-lovan/workflow.wf
+++ b/workflows/viral-lovan/workflow.wf
@@ -32,9 +32,6 @@
       },
       {
          "name" : "annotate_null_to_hypothetical"
-      },
-      {
-         "name" : "compute_genome_quality_control"
       }
-   ]
+  ]
 }


### PR DESCRIPTION
The bacterial quality check is overwriting the lovan quality data.