### PR TITLE
Final spec change for job metadata.

### DIFF
--- a/GenomeAnnotation.spec
+++ b/GenomeAnnotation.spec
@@ -427,13 +427,14 @@ module GenomeAnnotation
 	list<computed_variant> computed_variants;
 
 	structure {
+	    string user;
 	    float job_start;
 	    float job_end;
 	    float job_elapsed;
 	    string hostname;
 	    string container;
 	    string slurm_jobname;
-	    int slurm_jobid;
+	    string slurm_jobid;
 	    freeform workflow;
 	    freeform params;
 	} job_metadata;

--- a/lib/Bio/KBase/GenomeAnnotation/Client.pm
+++ b/lib/Bio/KBase/GenomeAnnotation/Client.pm
@@ -152,13 +152,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -495,13 +496,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -904,13 +906,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -1257,13 +1260,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -1655,13 +1659,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -1998,13 +2003,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -2397,13 +2403,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -2740,13 +2747,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -3139,13 +3147,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -3482,13 +3491,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -3882,13 +3892,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -4236,13 +4247,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -4647,13 +4659,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -4991,13 +5004,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -5392,13 +5406,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -5736,13 +5751,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -6137,13 +6153,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -6480,13 +6497,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -6879,13 +6897,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -7222,13 +7241,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -7622,13 +7642,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -7972,13 +7993,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -8378,13 +8400,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -8741,13 +8764,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -9160,13 +9184,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -9512,13 +9537,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -10152,13 +10178,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -10495,13 +10522,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -10895,13 +10923,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -11238,13 +11267,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -11637,13 +11667,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -11980,13 +12011,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -12379,13 +12411,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -12722,13 +12755,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -13121,13 +13155,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -13464,13 +13499,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -13863,13 +13899,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -14206,13 +14243,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -14605,13 +14643,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -14948,13 +14987,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -15348,13 +15388,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -15693,13 +15734,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -16101,13 +16143,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -16444,13 +16487,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -16844,13 +16888,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -17187,13 +17232,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -17588,13 +17634,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -17934,13 +17981,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -18337,13 +18385,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -18684,13 +18733,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -19088,13 +19138,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -19434,13 +19485,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -19837,13 +19889,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -20183,13 +20236,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -20585,13 +20639,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -20928,13 +20983,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -21327,13 +21383,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -21670,13 +21727,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -22069,13 +22127,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -22412,13 +22471,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -22812,13 +22872,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -23160,13 +23221,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -23565,13 +23627,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -23913,13 +23976,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -24317,13 +24381,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -24660,13 +24725,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -25060,13 +25126,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -25407,13 +25474,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -25810,13 +25878,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -26153,13 +26222,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -26554,13 +26624,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -26899,13 +26970,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -27301,13 +27373,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -27648,13 +27721,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -28059,13 +28133,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -28405,13 +28480,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -28807,13 +28883,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -29150,13 +29227,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -29550,13 +29628,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -29897,13 +29976,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -30301,13 +30381,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -30648,13 +30729,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -31052,13 +31134,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -31409,13 +31492,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -31823,13 +31907,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -32174,13 +32259,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -32582,13 +32668,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -32928,13 +33015,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -33331,13 +33419,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -33677,13 +33766,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -34080,13 +34170,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -34437,13 +34528,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -34851,13 +34943,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -35202,13 +35295,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -35672,13 +35766,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -36024,13 +36119,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -36432,13 +36528,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -36775,13 +36872,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -37174,13 +37272,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -37517,13 +37616,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -37916,13 +38016,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -38259,13 +38360,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -38658,13 +38760,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -39001,13 +39104,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -39400,13 +39504,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -39743,13 +39848,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -40142,13 +40248,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -40485,13 +40592,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -40884,13 +40992,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -41227,13 +41336,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -41626,13 +41736,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -41986,13 +42097,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -42402,13 +42514,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -42745,13 +42858,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -43144,13 +43258,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -43487,13 +43602,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -43886,13 +44002,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -44229,13 +44346,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -44628,13 +44746,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -44971,13 +45090,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -45370,13 +45490,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -45713,13 +45834,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -46112,13 +46234,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -46455,13 +46578,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -46858,13 +46982,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -47205,13 +47330,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -47606,13 +47732,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -47949,13 +48076,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -48349,13 +48477,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -48692,13 +48821,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -49092,13 +49222,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -49438,13 +49569,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -49842,13 +49974,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -50187,13 +50320,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -50976,13 +51110,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -51319,13 +51454,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -51718,13 +51854,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -52061,13 +52198,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -53056,13 +53194,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -53439,13 +53578,14 @@ genomeTO is a reference to a hash where the following keys are defined:
 	sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 	computed_variants has a value which is a reference to a list where each element is a computed_variant
 	job_metadata has a value which is a reference to a hash where the following keys are defined:
+	user has a value which is a string
 	job_start has a value which is a float
 	job_end has a value which is a float
 	job_elapsed has a value which is a float
 	hostname has a value which is a string
 	container has a value which is a string
 	slurm_jobname has a value which is a string
-	slurm_jobid has a value which is an int
+	slurm_jobid has a value which is a string
 	workflow has a value which is a freeform
 	params has a value which is a freeform
 
@@ -55731,13 +55871,14 @@ annotation has a value which is a job_statistics
 sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 computed_variants has a value which is a reference to a list where each element is a computed_variant
 job_metadata has a value which is a reference to a hash where the following keys are defined:
+user has a value which is a string
 job_start has a value which is a float
 job_end has a value which is a float
 job_elapsed has a value which is a float
 hostname has a value which is a string
 container has a value which is a string
 slurm_jobname has a value which is a string
-slurm_jobid has a value which is an int
+slurm_jobid has a value which is a string
 workflow has a value which is a freeform
 params has a value which is a freeform
 
@@ -55782,13 +55923,14 @@ annotation has a value which is a job_statistics
 sra_metadata has a value which is a reference to a list where each element is a reference to a hash where the key is a string and the value is a string
 computed_variants has a value which is a reference to a list where each element is a computed_variant
 job_metadata has a value which is a reference to a hash where the following keys are defined:
+user has a value which is a string
 job_start has a value which is a float
 job_end has a value which is a float
 job_elapsed has a value which is a float
 hostname has a value which is a string
 container has a value which is a string
 slurm_jobname has a value which is a string
-slurm_jobid has a value which is an int
+slurm_jobid has a value which is a string
 workflow has a value which is a freeform
 params has a value which is a freeform
 

--- a/lib/Bio/KBase/GenomeAnnotation/Client.pm
+++ b/lib/Bio/KBase/GenomeAnnotation/Client.pm
@@ -5,11 +5,7 @@ use strict;
 use Data::Dumper;
 use URI;
 
-my $get_time = sub { time, 0 };
-eval {
-    require Time::HiRes;
-    $get_time = sub { Time::HiRes::gettimeofday() };
-};
+use Time::HiRes qw(gettimeofday);
 
 use P3AuthToken;
 
@@ -59,7 +55,7 @@ sub new
     }
     else
     {
-	my ($t, $us) = &$get_time();
+	my ($t, $us) = gettimeofday;
 	$us = sprintf("%06d", $us);
 	my $ts = strftime("%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t);
 	$self->{kbrpc_tag} = "C:$0:$self->{hostname}:$$:$ts";

--- a/lib/Bio/KBase/GenomeAnnotation/Service.pm
+++ b/lib/Bio/KBase/GenomeAnnotation/Service.pm
@@ -775,7 +775,7 @@ sub redirect_both
 sub timestamp
 {
     my($self) = @_;
-    my ($t, $us) = gettimeofday;
+    my ($t, $us) = $self->{get_time}->();
     $us = sprintf("%06d", $us);
     my $ts = strftime("%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t);
     return $ts;

--- a/lib/Bio/KBase/GenomeAnnotation/Service.pm
+++ b/lib/Bio/KBase/GenomeAnnotation/Service.pm
@@ -10,12 +10,8 @@ use File::Temp;
 use File::Slurp;
 use Class::Load qw();
 use Config::Simple;
+use Time::HiRes qw(gettimeofday);
 
-my $get_time = sub { time, 0 };
-eval {
-    require Time::HiRes;
-    $get_time = sub { Time::HiRes::gettimeofday(); };
-};
 
 use P3AuthToken;
 use P3TokenValidator;
@@ -520,7 +516,7 @@ sub call_method {
 	{
 	    $self->{hostname} ||= $g_hostname;
 
-	    my ($t, $us) = &$get_time();
+	    my ($t, $us) = gettimeofday;
 	    $us = sprintf("%06d", $us);
 	    my $ts = strftime("%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t);
 	    $tag = "S:$self->{hostname}:$$:$ts";
@@ -531,7 +527,7 @@ sub call_method {
 	local $ENV{KBRPC_METADATA} = $kb_metadata if $kb_metadata;
 	local $ENV{KBRPC_ERROR_DEST} = $kb_errordest if $kb_errordest;
 
-	my $stderr = Bio::KBase::GenomeAnnotation::ServiceStderrWrapper->new($ctx, $get_time);
+	my $stderr = Bio::KBase::GenomeAnnotation::ServiceStderrWrapper->new($ctx);
 	$ctx->stderr($stderr);
 
 	#
@@ -690,9 +686,8 @@ use Time::HiRes 'gettimeofday';
 
 sub new
 {
-    my($class, $ctx, $get_time) = @_;
+    my($class, $ctx) = @_;
     my $self = {
-	get_time => $get_time,
     };
     my $dest = $ENV{KBRPC_ERROR_DEST} if exists $ENV{KBRPC_ERROR_DEST};
     my $tag = $ENV{KBRPC_TAG} if exists $ENV{KBRPC_TAG};
@@ -775,7 +770,7 @@ sub redirect_both
 sub timestamp
 {
     my($self) = @_;
-    my ($t, $us) = $self->{get_time}->();
+    my ($t, $us) = gettimeofday;
     $us = sprintf("%06d", $us);
     my $ts = strftime("%Y-%m-%dT%H:%M:%S.${us}Z", gmtime $t);
     return $ts;


### PR DESCRIPTION
Also recompiled against latest typecomp that removed the get_time from stubs.